### PR TITLE
refactor: add local API configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Local configuration and secrets
+config.local.php
+.env
+
+# OS/editor files
+.DS_Store
+Thumbs.db
+.vscode/
+.idea/

--- a/LOCAL_SETUP.md
+++ b/LOCAL_SETUP.md
@@ -1,0 +1,73 @@
+# Local setup - ElTesoroDeMongliAPI
+
+## 1. Copy local config
+
+Copy:
+
+```text
+config.example.php -> config.local.php
+```
+
+`config.local.php` is ignored by Git and is the only place where local credentials should be stored.
+
+## 2. Database
+
+Create the database:
+
+```sql
+CREATE DATABASE eltesorodemongli
+CHARACTER SET utf8mb4
+COLLATE utf8mb4_unicode_ci;
+```
+
+Create a local database user and grant permissions for development.
+
+Then run:
+
+```text
+migrations/001_create_initial_schema.sql
+```
+
+## 3. Mail in local development
+
+For local development, keep mail disabled in `config.local.php` unless SMTP is configured.
+
+When mail is disabled, register still creates the user and activation token, but no email is sent. You can activate local test users manually in the database:
+
+```sql
+UPDATE users SET active = 1 WHERE mail = 'test@example.com';
+```
+
+If SMTP is needed, configure it only in `config.local.php`. Do not commit real SMTP credentials.
+
+## 4. Test endpoints
+
+Register:
+
+```powershell
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "http://localhost/ElTesoroDeMongliAPI/register/" `
+  -ContentType "application/json" `
+  -Body '{"mail":"test@example.com","password":"Test1234!","nickname":"Tester"}'
+```
+
+Login:
+
+```powershell
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "http://localhost/ElTesoroDeMongliAPI/login/" `
+  -ContentType "application/json" `
+  -Body '{"mail":"test@example.com","password":"Test1234!"}'
+```
+
+Get users:
+
+```powershell
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "http://localhost/ElTesoroDeMongliAPI/get_users/" `
+  -ContentType "application/json" `
+  -Body '{}'
+```

--- a/activationMail/index.php
+++ b/activationMail/index.php
@@ -1,4 +1,5 @@
 <?php
+require $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/config_loader.php';
 require $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/PHPMailer.php';
 require $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/SMTP.php';
 require $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/Exception.php';
@@ -7,29 +8,31 @@ use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\PHPMailer\Exception;
 
-
 function sendValidationEmail($recipientEmail, $nickname, $validationLink) {
+    $config = mongli_config();
+    $mailConfig = $config['mail'];
+
+    if (empty($mailConfig['enabled'])) {
+        return;
+    }
+
     $phpMail = new PHPMailer(true);
 
     try {
-        // Configuración del servidor
         $phpMail->SMTPDebug = SMTP::DEBUG_OFF;
         $phpMail->isSMTP();
-        $phpMail->Host = 'smtpout.secureserver.net';
+        $phpMail->Host = $mailConfig['host'];
         $phpMail->SMTPAuth = true;
-        $phpMail->Username = 'connect@jantechnology.es';
-        $phpMail->Password = 'Mongli2023';
+        $phpMail->Username = $mailConfig['username'];
+        $phpMail->Password = $mailConfig['password'];
         $phpMail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
-        // $mail->SMTPSecure = "tls";
-        $phpMail->Port = 587;
+        $phpMail->Port = intval($mailConfig['port']);
 
-        // Remitente y destinatario
-        $phpMail->setFrom('connect@jantechnology.es', 'El tesoro de Mongli');
+        $phpMail->setFrom($mailConfig['from_email'], $mailConfig['from_name']);
         $phpMail->addAddress($recipientEmail, $nickname);
 
-        // Contenido del correo
         $phpMail->isHTML(true);
-        $phpMail->Subject = 'Valid tu cuenta de El tesoro de Mongli';
+        $phpMail->Subject = 'Valida tu cuenta de El tesoro de Mongli';
         $phpMail->Body = '
             <!DOCTYPE html>
             <html lang="es">
@@ -60,27 +63,27 @@ function sendValidationEmail($recipientEmail, $nickname, $validationLink) {
             </body>
             </html>';
 
-        // Enviar correo
         $phpMail->send();
-        // echo 'Mensaje enviado correctamente';
     } catch (Exception $e) {
-        // $error_code = 11;
-        echo "No se pudo enviar el mensaje. Error: {$phpMail->ErrorInfo}";
+        error_log("Activation email could not be sent: {$phpMail->ErrorInfo}");
     }
 }
 
 function obtenerUrlServidor() {
+    $config = mongli_config();
+
+    if (!empty($config['app']['base_url'])) {
+        return rtrim($config['app']['base_url'], '/');
+    }
+
     $protocolo = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https://' : 'http://';
     $nombreServidor = $_SERVER['SERVER_NAME'];
     $puerto = $_SERVER['SERVER_PORT'] == '80' || $_SERVER['SERVER_PORT'] == '443' ? '' : ':' . $_SERVER['SERVER_PORT'];
-    $ruta = $protocolo . $nombreServidor . $puerto;
-    
-    return $ruta;
+
+    return $protocolo . $nombreServidor . $puerto;
 }
 
 $urlServidor = obtenerUrlServidor();
-
-// Ejemplo de uso
 $validationLink = $urlServidor . '/ElTesoroDeMongliAPI/validation?user_id=' . $new_user_id . '&token=' . $token;
 sendValidationEmail($mail, $nickname, $validationLink);
 ?>

--- a/activationMail/index.php
+++ b/activationMail/index.php
@@ -1,8 +1,8 @@
 <?php
-require $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/config_loader.php';
-require $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/PHPMailer.php';
-require $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/SMTP.php';
-require $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/Exception.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/config_loader.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/PHPMailer.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/SMTP.php';
+require_once $_SERVER['DOCUMENT_ROOT'] . '/ElTesoroDeMongliAPI/PHPMailer/src/Exception.php';
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;

--- a/config.example.php
+++ b/config.example.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'database' => [
+        'host' => 'localhost',
+        'user' => 'mongli_dev',
+        'password' => 'CHANGE_ME_LOCAL_PASSWORD',
+        'name' => 'eltesorodemongli',
+        'charset' => 'utf8mb4',
+    ],
+    'mail' => [
+        // Keep false for local development unless SMTP is configured.
+        'enabled' => false,
+        'host' => 'smtp.example.com',
+        'username' => 'user@example.com',
+        'password' => 'CHANGE_ME_SMTP_PASSWORD',
+        'port' => 587,
+        'from_email' => 'noreply@example.com',
+        'from_name' => 'El tesoro de Mongli',
+    ],
+    'app' => [
+        // Leave empty to auto-detect from the current request.
+        'base_url' => '',
+    ],
+];
+
+?>

--- a/config_loader.php
+++ b/config_loader.php
@@ -1,0 +1,70 @@
+<?php
+
+function mongli_array_merge_recursive_distinct(array $base, array $override): array
+{
+    foreach ($override as $key => $value) {
+        if (is_array($value) && isset($base[$key]) && is_array($base[$key])) {
+            $base[$key] = mongli_array_merge_recursive_distinct($base[$key], $value);
+        } else {
+            $base[$key] = $value;
+        }
+    }
+
+    return $base;
+}
+
+function mongli_env_bool(string $name, bool $default = false): bool
+{
+    $value = getenv($name);
+
+    if ($value === false || $value === '') {
+        return $default;
+    }
+
+    return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+}
+
+function mongli_config(): array
+{
+    static $config = null;
+
+    if ($config !== null) {
+        return $config;
+    }
+
+    $config = [
+        'database' => [
+            'host' => getenv('MONGLI_DB_HOST') ?: 'localhost',
+            'user' => getenv('MONGLI_DB_USER') ?: '',
+            'password' => getenv('MONGLI_DB_PASSWORD') ?: '',
+            'name' => getenv('MONGLI_DB_NAME') ?: 'eltesorodemongli',
+            'charset' => getenv('MONGLI_DB_CHARSET') ?: 'utf8mb4',
+        ],
+        'mail' => [
+            'enabled' => mongli_env_bool('MONGLI_MAIL_ENABLED', false),
+            'host' => getenv('MONGLI_MAIL_HOST') ?: '',
+            'username' => getenv('MONGLI_MAIL_USERNAME') ?: '',
+            'password' => getenv('MONGLI_MAIL_PASSWORD') ?: '',
+            'port' => intval(getenv('MONGLI_MAIL_PORT') ?: 587),
+            'from_email' => getenv('MONGLI_MAIL_FROM_EMAIL') ?: '',
+            'from_name' => getenv('MONGLI_MAIL_FROM_NAME') ?: 'El tesoro de Mongli',
+        ],
+        'app' => [
+            'base_url' => getenv('MONGLI_APP_BASE_URL') ?: '',
+        ],
+    ];
+
+    $localConfigPath = __DIR__ . '/config.local.php';
+
+    if (file_exists($localConfigPath)) {
+        $localConfig = require $localConfigPath;
+
+        if (is_array($localConfig)) {
+            $config = mongli_array_merge_recursive_distinct($config, $localConfig);
+        }
+    }
+
+    return $config;
+}
+
+?>

--- a/connection.php
+++ b/connection.php
@@ -1,16 +1,27 @@
 <?php
-// Configuración de la conexión a la base de datos
-$servername = "localhost";
-$username = "mongli_fck";
-$password = "bTT*fci7YRQpmXsh";
-$dbname = "eltesorodemongli";
 
-// Crear conexión
-$conn = new mysqli($servername, $username, $password, $dbname);
+require_once __DIR__ . '/config_loader.php';
 
-// Verificar conexión
+$config = mongli_config();
+$dbConfig = $config['database'];
+
+$conn = new mysqli(
+    $dbConfig['host'],
+    $dbConfig['user'],
+    $dbConfig['password'],
+    $dbConfig['name']
+);
+
 if ($conn->connect_error) {
-    die("Error de conexión: " . $conn->connect_error);
+    http_response_code(500);
+    die(json_encode([
+        'error_code' => 500,
+        'message' => 'Database connection failed',
+    ]));
+}
+
+if (!empty($dbConfig['charset'])) {
+    $conn->set_charset($dbConfig['charset']);
 }
 
 ?>

--- a/migrations/001_create_initial_schema.sql
+++ b/migrations/001_create_initial_schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS users (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    mail VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    nickname VARCHAR(20) NOT NULL UNIQUE,
+    active TINYINT(1) NOT NULL DEFAULT 0,
+    transform JSON NULL,
+    last_login DATETIME NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS access_tokens (
+    user_id INT UNSIGNED NOT NULL PRIMARY KEY,
+    token CHAR(64) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_access_tokens_user
+        FOREIGN KEY (user_id) REFERENCES users(id)
+        ON DELETE CASCADE,
+    INDEX idx_access_tokens_token (token)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary

Adds local configuration support for the PHP API and removes hardcoded database/mail settings from runtime code.

## Changes

- Add `config_loader.php`.
- Add `config.example.php`.
- Add `.gitignore` for local config/secrets.
- Refactor `connection.php` to read database settings from config/env.
- Refactor `activationMail` to read SMTP settings from config/env and allow mail to be disabled locally.
- Add initial DB migration: `migrations/001_create_initial_schema.sql`.
- Add `LOCAL_SETUP.md` with local setup notes.

## Notes

Mail is disabled by default for local development. Local users can be activated manually in the database while developing.

No real credentials are added in this PR.